### PR TITLE
Added attribute quotes for ColumnAlign.

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -84,8 +84,8 @@ impl fmt::Display for ColumnAlign {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ColumnAlign::Center => write!(f, r#""#),
-            ColumnAlign::Left => write!(f, r#" columnalign=left"#),
-            ColumnAlign::Right => write!(f, r#" columnalign=right"#),
+            ColumnAlign::Left => write!(f, r#" columnalign="left""#),
+            ColumnAlign::Right => write!(f, r#" columnalign="right""#),
         }
     }
 }


### PR DESCRIPTION
Thanks for the great library. I use it a lot.

I get some HTML parsing errors because ColumnAlign does not produce quotes round attributes. Could you please accept this pull request, and publish a new version on crates.io?